### PR TITLE
refactor:모든 dto 타입을 class 타입에서 record 타입으로 변경

### DIFF
--- a/src/main/java/gdgoc/be/dto/CalculationResult.java
+++ b/src/main/java/gdgoc/be/dto/CalculationResult.java
@@ -7,13 +7,23 @@ import lombok.AllArgsConstructor; // Add this import
 
 import java.math.BigDecimal;
 
-@Getter
-@Setter
+
 @Builder
-@AllArgsConstructor // Add this annotation
-public class CalculationResult {
-    private BigDecimal totalAmount;      // 총 상품 금액 (할인 전)
-    private BigDecimal discountAmount;   // 할인 금액
-    private BigDecimal shippingFee;      // 배송비
-    private BigDecimal finalAmount;      // 최종 결제 금액
+public record CalculationResult(
+
+        BigDecimal totalAmount,
+        BigDecimal discountAmount,
+        BigDecimal shippingFee,
+        BigDecimal finalAmount
+) {
+
+    public static CalculationResult of(BigDecimal totalAmount, BigDecimal discountAmount,
+                                       BigDecimal shippingFee, BigDecimal finalAmount) {
+        return CalculationResult.builder()
+                .totalAmount(totalAmount)
+                .discountAmount(discountAmount)
+                .shippingFee(shippingFee)
+                .finalAmount(finalAmount)
+                .build();
+    }
 }

--- a/src/main/java/gdgoc/be/dto/CartDeleteRequest.java
+++ b/src/main/java/gdgoc/be/dto/CartDeleteRequest.java
@@ -6,11 +6,8 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class CartDeleteRequest {
+public record CartDeleteRequest(
+        List<Long> itemIds
+) {
 
-    // itemId 를 일괄로 받아 한 번에 삭제
-    public List<Long> itemIds;
 }

--- a/src/main/java/gdgoc/be/dto/CartRequest.java
+++ b/src/main/java/gdgoc/be/dto/CartRequest.java
@@ -8,14 +8,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class CartRequest {
+public record CartRequest(
 
-    @NotNull(message = "메뉴 ID는 필수입니다.")
-    private Long menuId;
-    @Min(value = 1, message = "수량은 최소 1개 이상이어야 합니다.")
-    @Positive(message = "양수만 입력 가능합니다.")
-    private int quantity;
+        @NotNull(message = "메뉴 ID는 필수입니다.")
+        long menuId,
+
+        @Min(value = 1, message = "수량은 최소 1개 이상이어야 합니다.")
+        @Positive(message = "양수만 입력 가능합니다.")
+        int quantity
+) {
 }

--- a/src/main/java/gdgoc/be/dto/CartResponse.java
+++ b/src/main/java/gdgoc/be/dto/CartResponse.java
@@ -1,20 +1,25 @@
 package gdgoc.be.dto;
 
 
-import lombok.AllArgsConstructor;
+import gdgoc.be.domain.CartItem;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class CartResponse {
+public record CartResponse(
+        Long itemId,
+        String menuName,
+        int price,
+        int quantity,
+        boolean isAvailable
+) {
 
-    private Long itemId;
-    private String menuName;
-    private int price;
-    private int quantity;
-    private boolean isAvailable; // [요구사항] 품절 여부 판단 필드
+    public static CartResponse from(CartItem item) {
+        return CartResponse.builder()
+                .itemId(item.getId())
+                .menuName(item.getMenu().getName())
+                .price(item.getMenu().getPrice())
+                .quantity(item.getQuantity())
+                .isAvailable(item.getMenu().getStock() >0)
+                .build();
+    }
 }

--- a/src/main/java/gdgoc/be/dto/MenuDetailResponse.java
+++ b/src/main/java/gdgoc/be/dto/MenuDetailResponse.java
@@ -1,16 +1,30 @@
 package gdgoc.be.dto;
 
+import gdgoc.be.domain.Menu;
 import lombok.*;
 
-@Getter @Builder
-@NoArgsConstructor @AllArgsConstructor
-public class MenuDetailResponse {
-    private Long id;
-    private String name;
-    private int price;
-    private String description;
-    private Integer stock;
-    private String status;
-    private String category;
-    private boolean isAvailable; // 재고가 0 보다 클 시 true 를 저장
+@Builder
+public record MenuDetailResponse(
+        Long id,
+        String name,
+        int price,
+        String description,
+        Integer stock,
+        String status,
+        String category,
+        boolean isAvailable
+) {
+
+    public static MenuDetailResponse from(Menu menu) {
+
+        return MenuDetailResponse.builder()
+                .id(menu.getId())
+                .name(builder().name)
+                .price(menu.getPrice())
+                .description(menu.getDescription())
+                .category(menu.getCategory().name())
+                .isAvailable(menu.isAvailable())
+                .status(menu.getStock() >0 ? "판매 중" : "품절")
+                .build();
+    }
 }

--- a/src/main/java/gdgoc/be/dto/MenuResponse.java
+++ b/src/main/java/gdgoc/be/dto/MenuResponse.java
@@ -1,18 +1,23 @@
 package gdgoc.be.dto;
 
 
+import gdgoc.be.domain.Menu;
 import lombok.Builder;
-import lombok.Getter;
 
+@Builder
+public record MenuResponse(
+        Long id,
+        String name,
+        int price,
+        String category
+) {
 
-import lombok.*;
-import java.math.BigDecimal;
-
-@Getter @Builder
-@NoArgsConstructor @AllArgsConstructor
-public class MenuResponse {
-    private Long id;
-    private String name;
-    private int price;
-    private String category;
+    public static MenuResponse from(Menu menu) {
+        return MenuResponse.builder()
+                .id(menu.getId())
+                .name(menu.getName())
+                .price(menu.getPrice())
+                .category(menu.getCategory().name())
+                .build();
+    }
 }

--- a/src/main/java/gdgoc/be/dto/OrderItemRequest.java
+++ b/src/main/java/gdgoc/be/dto/OrderItemRequest.java
@@ -1,0 +1,12 @@
+package gdgoc.be.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record OrderItemRequest(
+        @NotNull(message = "메뉴 ID는 필수입니다.")
+        Long menuId,
+        @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
+        int quantity
+) {
+}

--- a/src/main/java/gdgoc/be/dto/OrderItemResponse.java
+++ b/src/main/java/gdgoc/be/dto/OrderItemResponse.java
@@ -1,0 +1,26 @@
+package gdgoc.be.dto;
+
+import gdgoc.be.domain.OrderItem;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+@Builder
+public record OrderItemResponse(
+        Long orderItemId,
+        Long menuId,
+        String menuName,
+        BigDecimal pricePerItem, // 변경
+        int quantity
+) {
+
+    public static OrderItemResponse from(OrderItem orderItem) {
+        return OrderItemResponse.builder()
+                .orderItemId(orderItem.getId())
+                .menuId(orderItem.getMenu().getId())
+                .menuName(orderItem.getMenu().getName())
+                .pricePerItem(orderItem.getOrderPrice())
+                .quantity(orderItem.getQuantity())
+                .build();
+    }
+}

--- a/src/main/java/gdgoc/be/dto/OrderRequest.java
+++ b/src/main/java/gdgoc/be/dto/OrderRequest.java
@@ -1,31 +1,18 @@
 package gdgoc.be.dto;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import jakarta.annotation.Nullable;
-import lombok.Getter;
-import lombok.Setter;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
-@Getter
-@Setter
-public class OrderRequest {
-    @Valid
-    @NotNull(message = "주문할 상품 목록은 필수입니다.")
-    private List<OrderItemRequest> orderItems;
+public record OrderRequest(
 
-    @Nullable
-    private Long couponId;
+        @Valid
+        @NotNull(message = "주문할 상품 목록은 필수입니다.")
+        List<OrderItemRequest> orderItems,
 
-    @Getter
-    @Setter
-    public static class OrderItemRequest {
-        @NotNull(message = "메뉴 ID는 필수입니다.")
-        private Long menuId;
-
-        @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
-        private int quantity;
-    }
+        @Nullable
+        Long couponId
+) {
 }

--- a/src/main/java/gdgoc/be/dto/OrderResponse.java
+++ b/src/main/java/gdgoc/be/dto/OrderResponse.java
@@ -1,30 +1,26 @@
 package gdgoc.be.dto;
 
 import gdgoc.be.domain.Order;
-import gdgoc.be.domain.OrderItem;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Getter
-@Setter
 @Builder
-public class OrderResponse {
-    private Long orderId;
-    private LocalDateTime orderDate;
-    private String orderStatus;
-    private String address; // 추가
-    private List<OrderItemResponse> orderItems;
-    private BigDecimal totalPrice;
-    private BigDecimal totalDiscount; // 임시 값
-    private BigDecimal shippingFee;   // 임시 값
-    private BigDecimal finalPrice;
-    private Long couponId;
+public record OrderResponse(
+        Long orderId,
+        LocalDateTime orderDate,
+        String orderStatus,
+        String address,
+        List<OrderItemResponse> orderItems,
+        BigDecimal totalPrice,
+        BigDecimal totalDiscount,
+        BigDecimal shippingFee,
+        BigDecimal finalPrice,
+        Long couponId
+) {
 
     public static OrderResponse from(Order order) {
         return OrderResponse.builder()
@@ -41,26 +37,5 @@ public class OrderResponse {
                 .finalPrice(order.getFinalAmount()) // 매핑
                 .couponId(order.getCouponId()) // couponId 매핑
                 .build();
-    }
-
-    @Getter
-    @Setter
-    @Builder
-    public static class OrderItemResponse {
-        private Long orderItemId;
-        private Long menuId;
-        private String menuName;
-        private BigDecimal pricePerItem; // 변경
-        private int quantity;
-
-        public static OrderItemResponse from(OrderItem orderItem) {
-            return OrderItemResponse.builder()
-                    .orderItemId(orderItem.getId())
-                    .menuId(orderItem.getMenu().getId())
-                    .menuName(orderItem.getMenu().getName())
-                    .pricePerItem(orderItem.getOrderPrice())
-                    .quantity(orderItem.getQuantity())
-                    .build();
-        }
     }
 }


### PR DESCRIPTION
## 변경 사항
- 기존 class 타입의 dto 를 record 타입으로 변경

## 변경 이유

- 불변성(Immutability) 성립: DTO 의 목적은 오직 데이터 전달입니다. 여러 계층을 이동하며 데이터 수정은 발생해선 안됩니다.  record 타입은 모든 필드에 자동으로 final 이 선언되어 불변성을 보장합니다.
-  보일러 플레이드 제거: getter, hashCode 등 반복적인 코드를 작성하는 것은 가독성을 저하시키지만 record 타입은 해당 메서드를 명시하지 않아도 자동으로 생성합니다.

⚠️ 주의: setter 는 **불변성 객체**이기 때문에 생성하지 않음.

## 관련 이슈
-  #4 

## 체크리스트
- [x] 컨벤션 준수
- [ ] 테스트 코드 실행 확인

## 추가 필요 작업
- 현재 dto 에서 혼용 중인 int, long, BigDecimal 타입의 사용 근거를 명확히 하고, 데이터의 도메인 성격(금액, 수량, ID 등)에 맞춰 타입을 통일할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Converted data transfer objects to Java records throughout cart management, menu operations, order processing, and calculation services.
  * Removed Lombok-generated constructor, getter, and setter annotations from DTO classes.
  * Enhanced request validation with component-level constraints on cart and order items.
  * Added static factory methods for mapping domain objects to API response DTOs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->