### PR TITLE
refactor: cart 관련 api 수정

### DIFF
--- a/src/main/java/gdgoc/be/controller/CartController.java
+++ b/src/main/java/gdgoc/be/controller/CartController.java
@@ -1,6 +1,7 @@
 package gdgoc.be.controller;
 
 import gdgoc.be.common.api.ApiResponse;
+import gdgoc.be.dto.cart.CartBulkDeleteRequest;
 import gdgoc.be.dto.cart.CartRequest;
 import gdgoc.be.dto.cart.CartSummaryResponse;
 import gdgoc.be.dto.cart.CartUpdateRequest;
@@ -51,7 +52,7 @@ public class CartController {
     @PatchMapping("/{cartItemId}")
     public ApiResponse<Void> updateCart(
             @PathVariable Long cartItemId,
-            @Valid @RequestBody CartUpdateRequest request) { // DTO 사용
+            @Valid @RequestBody CartUpdateRequest request) {
 
         cartService.updateCartItem(cartItemId, request);
         return ApiResponse.success(null);
@@ -60,8 +61,9 @@ public class CartController {
     @Operation(summary = "장바구니 선택/전체 삭제", description = "ID 리스트를 보내면 선택 삭제, 보내지 않으면 전체 삭제를 수행합니다.",
             security = @SecurityRequirement(name = "bearerAuth"))
     @DeleteMapping
-    public ApiResponse<Void> deleteCartItems(@RequestBody(required = false) List<Long> cartItemIds) {
-        cartService.deleteCartItems(cartItemIds);
+    public ApiResponse<Void> deleteCartItems(@RequestBody(required = false) CartBulkDeleteRequest request) {
+        List<Long> ids = (request != null) ? request.cartItemIds() : null;
+        cartService.deleteCartItems(ids);
         return ApiResponse.success(null);
     }
 }

--- a/src/main/java/gdgoc/be/dto/cart/CartBulkDeleteRequest.java
+++ b/src/main/java/gdgoc/be/dto/cart/CartBulkDeleteRequest.java
@@ -1,0 +1,8 @@
+package gdgoc.be.dto.cart;
+
+import java.util.List;
+
+public record CartBulkDeleteRequest(
+        List<Long> cartItemIds
+) {
+}

--- a/src/main/java/gdgoc/be/dto/cart/CartResponse.java
+++ b/src/main/java/gdgoc/be/dto/cart/CartResponse.java
@@ -29,7 +29,7 @@ public record CartResponse(
                 .originalPrice(item.getProduct().getOriginalPrice())
                 .discountRate(item.getProduct().getDiscountRate())
                 .price(item.getProduct().getPrice())
-                .selectedSize("FREE")
+                .selectedSize(item.getSelectedSize())
                 .sizeOptions(item.getProduct().getSizesOptions())
                 .quantity(item.getQuantity())
                 .build();

--- a/src/main/java/gdgoc/be/dto/order/OrderCreateResponse.java
+++ b/src/main/java/gdgoc/be/dto/order/OrderCreateResponse.java
@@ -1,0 +1,23 @@
+package gdgoc.be.dto.order;
+
+import gdgoc.be.domain.Order;
+import lombok.Builder;
+
+@Builder
+public record OrderCreateResponse(
+        String orderId,
+        String orderStatus,
+        String paymentStatus,
+        Integer totalPrice,
+        String createdAt
+) {
+    public static OrderCreateResponse from(Order order) {
+        return OrderCreateResponse.builder()
+                .orderId(String.valueOf(order.getId()))
+                .orderStatus(order.getStatus().name())
+                .paymentStatus(order.getPaymentStatus().name())
+                .totalPrice(order.getFinalAmount().intValue())
+                .createdAt(order.getOrderDate().toString())
+                .build();
+    }
+}

--- a/src/main/java/gdgoc/be/dto/order/OrderListResponse.java
+++ b/src/main/java/gdgoc/be/dto/order/OrderListResponse.java
@@ -1,0 +1,36 @@
+package gdgoc.be.dto.order;
+
+import gdgoc.be.domain.Order;
+import lombok.Builder;
+import java.util.List;
+
+@Builder
+public record OrderListResponse(
+        String orderId,
+        String representativeItem,
+        Integer totalPrice,
+        String orderStatus,
+        String createdAt,
+        List<OrderItemResponse> items
+) {
+    public static OrderListResponse from(Order order) {
+        List<OrderItemResponse> itemResponses = order.getOrderItems().stream()
+                .map(OrderItemResponse::from)
+                .toList();
+
+        // 대표 상품명 생성 로직
+        String repName = itemResponses.isEmpty() ? "" : itemResponses.get(0).productName();
+        if (itemResponses.size() > 1) {
+            repName += " 외 " + (itemResponses.size() - 1) + "건";
+        }
+
+        return OrderListResponse.builder()
+                .orderId(String.valueOf(order.getId()))
+                .representativeItem(repName)
+                .totalPrice(order.getFinalAmount().intValue())
+                .orderStatus(order.getStatus().name())
+                .createdAt(order.getOrderDate().toString())
+                .items(itemResponses)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 작업 요약
- 주문(Order) 및 장바구니(Cart) API의 요청/응답 구조를 개선하기 위해 용도별로 명확하게 DTO를 세분화 
- 컨트롤러의 반환 구조를 변경

## 구현 기능 
- **주문(Order) 응답 DTO 세분화 및 적용**
  - 주문 생성 API(`POST /api/orders`)의 응답을 전용 DTO인 `OrderCreateResponse`로 분리하여 적용
  - 주문 목록 조회 API(`GET /api/orders`)의 반환 타입을 기존 페이징(`Page`)에서 목록 전용 DTO인 `OrderListResponse`의 `List` 형태로 변경
- **장바구니(Cart) 요청 DTO 추가**
  - 장바구니 다중(선택) 삭제 요청 시 사용할 `CartBulkDeleteRequest` DTO 신규 추가

## 관련 이슈
- #34 

## ✅ 체크리스트
- [x] 컨벤션 준수
- [x] 테스트 코드 실행 확인

## 추가 필요 작업
- `OrderController` 내부에 직접 작성된 `getAllMyOrders()` 비즈니스 로직(JPA 엔티티 조회 및 `@Transactional` 처리 등)을 `OrderService` 계층으로 분리하는 리팩토링 필요
- 주문 목록 조회가 페이징(`Page`) 방식에서 전체 리스트(`List`) 반환으로 변경됨에 따른 프론트엔드 연동 로직 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cart items displaying incorrect size information; sizes now reflect actual product selection.

* **New Features**
  * Simplified order retrieval with improved order details in responses, including representative item summaries.

* **API Changes**
  * Updated cart deletion endpoint to accept structured request format.
  * Modified order list endpoint to return complete results without pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->