### PR TITLE
refactor: menuid >> productid로 수정

### DIFF
--- a/src/main/java/gdgoc/be/dto/order/OrderItemRequest.java
+++ b/src/main/java/gdgoc/be/dto/order/OrderItemRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record OrderItemRequest(
         @NotNull(message = "상품 ID는 필수입니다.")
-        Long menuId,
+        Long productId,
 
         @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
         int quantity,

--- a/src/main/java/gdgoc/be/handler/GlobalExceptionHandler.java
+++ b/src/main/java/gdgoc/be/handler/GlobalExceptionHandler.java
@@ -32,4 +32,15 @@ public class GlobalExceptionHandler {
                         null
                 ));
     }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        return ResponseEntity
+                .status(500)
+                .body(ApiResponse.fail(
+                        "INTERNAL_SERVER_ERROR",
+                        e.getMessage(),
+                        null
+                ));
+    }
 }

--- a/src/main/java/gdgoc/be/service/OrderService.java
+++ b/src/main/java/gdgoc/be/service/OrderService.java
@@ -68,7 +68,7 @@ public class OrderService {
         Order order = Order.createOrder(
                 user,
                 calculation,
-                null, // 주문 레벨 쿠폰은 더 이상 사용하지 않음
+                request.couponId(), // 주문 레벨 쿠폰 반영
                 request.shippingAddress()
         );
         orderItems.forEach(order::addOrderItem);
@@ -88,7 +88,7 @@ public class OrderService {
     private List<OrderItem> createOrderItems(List<OrderItemRequest> itemRequests, Long userId) {
         return itemRequests.stream()
                 .map(itemRequest -> {
-                    Product product = productRepository.findById(itemRequest.menuId())
+                    Product product = productRepository.findById(itemRequest.productId())
                             .orElseThrow(() -> new BusinessException(BusinessErrorCode.PRODUCT_NOT_FOUND));
 
                     UserCoupon userCoupon = null;
@@ -105,7 +105,7 @@ public class OrderService {
 
     private void clearOrderedItemsFromCart(Long userId, List<OrderItemRequest> items) {
         for (OrderItemRequest item : items) {
-            cartItemRepository.findByUserIdAndProductId(userId, item.menuId())
+            cartItemRepository.findByUserIdAndProductId(userId, item.productId())
                     .ifPresent(cartItemRepository::delete);
         }
     }
@@ -140,7 +140,7 @@ public class OrderService {
         // 1. 임시로 주문 아이템들 생성 (DB 저장 X)
         List<OrderItem> orderItems = request.orderItems().stream()
                 .map(itemRequest -> {
-                    Product product = productRepository.findById(itemRequest.menuId())
+                    Product product = productRepository.findById(itemRequest.productId())
                             .orElseThrow(() -> new BusinessException(BusinessErrorCode.PRODUCT_NOT_FOUND));
                     
                     UserCoupon userCoupon = null;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -95,6 +95,7 @@ DROP TABLE IF EXISTS orders CASCADE;
 CREATE TABLE orders (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     user_id BIGINT NOT NULL,
+    coupon_id BIGINT,
     total_amount DECIMAL(19, 2) NOT NULL,
     discount_amount DECIMAL(19, 2) NOT NULL,
     delivery_fee DECIMAL(19, 2) NOT NULL DEFAULT 0,
@@ -103,7 +104,8 @@ CREATE TABLE orders (
     payment_status VARCHAR(50) NOT NULL,
     address VARCHAR(255),
     order_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (user_id) REFERENCES users(id)
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    FOREIGN KEY (coupon_id) REFERENCES coupon(id)
 );
 
 -- 7. 주문 상세 (OrderItem)


### PR DESCRIPTION
## 📌 변경 사항
- [refactor] 코드 및 API 전반의 menuId 필드 및 변수명을 productId로 변경

## 🧐 구현 방식 & 이유
- 커머스 비즈니스 도메인 규격에 맞춰 기존 Menu 도메인이 Product로 전환됨에 따라, 식별자로 사용되던 변수 및 파라미터명(menuId)을 모두 productId로 통일하여 도메인 용어의 명확성과 일관성을 확보했습니다.

## 관련 이슈
- #49 

## ✅ 체크리스트
- [x] 컨벤션 준수
- [x] 테스트 코드 실행 확인